### PR TITLE
Support multiple terminals

### DIFF
--- a/CRM/Core/Payment/Redsys.php
+++ b/CRM/Core/Payment/Redsys.php
@@ -170,7 +170,19 @@ class CRM_Core_Payment_Redsys extends CRM_Core_Payment {
     if($redsys_settings['ipn_http'] == '1')
       $merchantUrl = preg_replace('/^https:/i', 'http:', $merchantUrl);
 
-    $merchantTerminal = empty($redsys_settings['merchant_terminal']) ? 1 : $redsys_settings['merchant_terminal'];
+    // Get the terminal for this payment processor
+    $paymentProcessorId = $params['payment_processor'];
+    if( array_key_exists('merchant_terminal_' . $paymentProcessorId, $redsys_settings) ) {
+      if( $redsys_settings['merchant_terminal_' . $paymentProcessorId] ) {
+        $merchantTerminal = $redsys_settings['merchant_terminal_' . $paymentProcessorId];
+      }
+    }
+    
+    // Use the default terminal if the processor doesn't have an assigned one
+    if( ! $merchantTerminal ) {
+      $merchantTerminal = empty($redsys_settings['merchant_terminal']) ? 1 :
+        $redsys_settings['merchant_terminal'];
+    }
 
     $miObj = new RedsysAPI;
     $miObj->setParameter("Ds_Merchant_Amount", $params["amount"] * 100);

--- a/CRM/Redsys/Form/Settings.php
+++ b/CRM/Redsys/Form/Settings.php
@@ -6,6 +6,15 @@ class CRM_Redsys_Form_Settings extends CRM_Core_Form {
   public function buildQuickForm() {
     $this->add('checkbox', 'ipn_http', 'Use http for IPN Callback');
     $this->add('text', 'merchant_terminal', 'Merchant Terminal', array('size' => 5));
+
+    $paymentProcessors = $this->getPaymentProcessors();
+    foreach( $paymentProcessors as $paymentProcessor ) {
+      $settingCode = 'merchant_terminal_' . $paymentProcessor[ "id" ];
+      $settingTitle = $paymentProcessor[ "name" ] . " (" .
+        ( $paymentProcessor["is_test"] == 0 ? "Live" : "Test" ) . ")";
+      $this->add('text', $settingCode, $settingTitle, array('size' => 5));
+    }
+
     $this->addButtons(array(
       array(
         'type' => 'submit',
@@ -29,10 +38,30 @@ class CRM_Redsys_Form_Settings extends CRM_Core_Form {
     $values = $this->exportValues();
     $redsys_settings['ipn_http'] = $values['ipn_http'];
     $redsys_settings['merchant_terminal'] = $values['merchant_terminal'];
+    
+    $paymentProcessors = $this->getPaymentProcessors();
+    foreach( $paymentProcessors as $paymentProcessor ) {
+      $settingId = 'merchant_terminal_' . $paymentProcessor[ "id" ];
+      $redsys_settings[$settingId] = $values[$settingId];
+    }
+    
     CRM_Core_BAO_Setting::setItem($redsys_settings, "Redsys Settings", 'redsys_settings');
     CRM_Core_Session::setStatus(ts('Redsys Settings Saved', array( 'domain' => 'com.ixiam.payment.redsys')), 'Configuration Updated', 'success');
 
     parent::postProcess();
   }
 
+  public function getPaymentProcessors() {
+    // Get the Redsys payment processor type
+    $redsysName = array( 'name' => 'Redsys' );
+    $paymentProcessorType = civicrm_api3( 'PaymentProcessorType', 'getsingle', $redsysName );
+
+    // Get the payment processors of Redsys type
+    $redsysType = array(
+      'payment_processor_type_id' => $paymentProcessorType[ 'id' ],
+      'is_active' => 1 );
+    $paymentProcessors = civicrm_api3( 'PaymentProcessor', 'get', $redsysType );
+
+    return $paymentProcessors["values"];
+  }
 }

--- a/templates/CRM/Redsys/Form/Settings.tpl
+++ b/templates/CRM/Redsys/Form/Settings.tpl
@@ -17,9 +17,29 @@
       <td>
         {$form.merchant_terminal.html}
         <br>
-        <span class="description">Merchant terminal number ("1" if not defined)</span>
+        <span class="description">Default merchant terminal number ("1" if not defined)</span>
       </td>
     </tr>
+
+    {foreach key=property item=terminal from=$form name=terminals}
+      {if $smarty.foreach.terminals.first}
+        <tr>
+          <th colspan="2">Merchant terminal numbers for specific payment prcessors</th>
+        </tr>
+      {/if}
+
+      {if $property|strpos:'merchant_terminal_' === 0}
+        <tr class="crm-redsys-form-block-merchant_terminal">
+          <td width="20%">
+            {$terminal.label}
+          </td>
+          <td>
+            {$terminal.html}
+          </td>
+        </tr>
+      {/if}
+    {/foreach}
+
   </table>
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}


### PR DESCRIPTION
Allows to use more than one terminal simultaneously in a CiviCRM instance:

![screenshot from 2016-12-20 11-33-00](https://cloud.githubusercontent.com/assets/1746692/21349127/26f6ecd0-c6a8-11e6-8922-4f15ffeec85c.png)

To configure your terminals, use the *civicrm/redsys/settings* url and set there the terminal number for each Redsys payment processor you've.